### PR TITLE
Remove Vertical Packing

### DIFF
--- a/src/components/builderPage/builderPage.jsx
+++ b/src/components/builderPage/builderPage.jsx
@@ -172,6 +172,7 @@ class Builder extends Component {
                     rowHeight={rowHeight}
                     width={getSize("width")}
                     onLayoutChange={this.saveLayout}
+                    compactType={null}
                     style={{
                         width: getSize("width"),
                         height: getSize("height"),

--- a/src/components/builderPage/builderPage.jsx
+++ b/src/components/builderPage/builderPage.jsx
@@ -173,6 +173,7 @@ class Builder extends Component {
                     width={getSize("width")}
                     onLayoutChange={this.saveLayout}
                     compactType={null}
+                    preventCollision={true}
                     style={{
                         width: getSize("width"),
                         height: getSize("height"),


### PR DESCRIPTION
This PR is one line, and very simple removes the "vertical compacting" that occurs by default in react-grid-layout.  With this PR, users will be able to place boxes anywhere on the page and they will stick, rather than get shifted up to fill empty space.  This large removes the need for the emptySpace component I contributed earlier (though I think we should keep that component regardless...for now).