### PR TITLE
Fix Delete Item button

### DIFF
--- a/src/components/builderPage/builderPage.jsx
+++ b/src/components/builderPage/builderPage.jsx
@@ -182,6 +182,7 @@ class Builder extends Component {
                             <button
                                 className="deleteItem"
                                 onClick={() => this.deleteItem(item.i)}
+                                onMouseDown={(event) => event.stopPropagation()}
                             >
                                 x
                             </button>


### PR DESCRIPTION
adds `onMouseDown={(event) => event.stopPropagation()}` to delete item button which prevents a mouseDown event from triggering a drag-n-drop routine before firing the click event.

Issue on react-grid-layout repo is here: https://github.com/react-grid-layout/react-grid-layout/issues/1980

Without this PR, deleting items seems to be a pain in the butt, not working most of the time.  I can only get items deleted by clicking down, moving cursor a tiny bit and quickly, and releasing.